### PR TITLE
Fixes remote files deletion #54

### DIFF
--- a/osync.sh
+++ b/osync.sh
@@ -2083,7 +2083,8 @@ local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 	## The following lines are executed remotely
 	function _logger {
 		local value="${1}" # What to log
-		echo -e "$value" >> "$LOG_FILE"
+		#echo -e "$value" >> "$LOG_FILE"
+		echo -e "$value" >&2 # writing to STDERR because
 
 		if [ $_SILENT -eq 0 ]; then
 		echo -e "$value"

--- a/osync.sh
+++ b/osync.sh
@@ -2187,7 +2187,7 @@ ENDSSH
 Logger "DELETE_CMD_INPUT: $DELETE_CMD_INPUT" "DEBUG"
 Logger "DELETE_CMD: ${DELETE_CMD[*]}" "DEBUG"
 
-	printf "%s" $DELETE_CMD_INPUT | ${DELETE_CMD[*]} > "$RUN_DIR/$PROGRAM.remote_deletion.$SCRIPT_PID" 2>&1
+	printf "%s" "$DELETE_CMD_INPUT" | ${DELETE_CMD[*]} > "$RUN_DIR/$PROGRAM.remote_deletion.$SCRIPT_PID" 2>&1
 
 	## Copy back the deleted failed file list
 	esc_source_file="$(EscapeSpaces "${TARGET[1]}${TARGET[3]}/$deleted_failed_list_file")"

--- a/osync.sh
+++ b/osync.sh
@@ -2075,8 +2075,11 @@ function _delete_remote {
 	fi
 
 #TODO: check output file without & and sleep 5
-$SSH_CMD ERROR_ALERT=0 sync_on_changes=$sync_on_changes _SILENT=$_SILENT _DEBUG=$_DEBUG _DRYRUN=$_DRYRUN _VERBOSE=$_VERBOSE COMMAND_SUDO=$COMMAND_SUDO FILE_LIST="$(EscapeSpaces "$TARGET_STATE_DIR/$deleted_list_file")" REPLICA_DIR="$(EscapeSpaces "$replica_dir")" DELETE_DIR="$(EscapeSpaces "$deletion_dir")" FAILED_DELETE_LIST="$(EscapeSpaces "${TARGET[1]}${TARGET[3]}/$deleted_failed_list_file")" 'bash -s' << 'ENDSSH' > "$RUN_DIR/$PROGRAM.remote_deletion.$SCRIPT_PID" 2>&1
-
+local TARGET_STATE_DIR="${TARGET[1]}${TARGET[3]}"
+local DELETE_CMD=(
+$SSH_CMD ERROR_ALERT=0 sync_on_changes=$sync_on_changes _SILENT=$_SILENT _DEBUG=$_DEBUG _DRYRUN=$_DRYRUN _VERBOSE=$_VERBOSE COMMAND_SUDO=$COMMAND_SUDO FILE_LIST="$(EscapeSpaces "$TARGET_STATE_DIR/$deleted_list_file")" REPLICA_DIR="$(EscapeSpaces "$replica_dir")" DELETE_DIR="$(EscapeSpaces "$deletion_dir")" FAILED_DELETE_LIST="$(EscapeSpaces "${TARGET[1]}${TARGET[3]}/$deleted_failed_list_file")" 'bash -s'
+)
+local DELETE_CMD_INPUT = $(cat << 'ENDSSH'
 	## The following lines are executed remotely
 	function _logger {
 		local value="${1}" # What to log
@@ -2177,6 +2180,11 @@ $SSH_CMD ERROR_ALERT=0 sync_on_changes=$sync_on_changes _SILENT=$_SILENT _DEBUG=
 	done
 	IFS=$OLD_IFS
 ENDSSH
+)
+Logger "DELETE_CMD_INPUT: $DELETE_CMD_INPUT" "DEBUG"
+Logger "DELETE_CMD: ${DELETE_CMD[*]}" "DEBUG"
+
+	printf "%s" $DELETE_CMD_INPUT | ${DELETE_CMD[*]} > "$RUN_DIR/$PROGRAM.remote_deletion.$SCRIPT_PID" 2>&1
 
 	## Copy back the deleted failed file list
 	esc_source_file="$(EscapeSpaces "${TARGET[1]}${TARGET[3]}/$deleted_failed_list_file")"

--- a/osync.sh
+++ b/osync.sh
@@ -2147,7 +2147,7 @@ local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 						$COMMAND_SUDO rm -rf "$REPLICA_DIR$DELETE_DIR/$files"
 					fi
 
-					if [ -e "$$REPLICA_DIR$files" ]; then
+					if [ -e "$REPLICA_DIR$files" ]; then
 						# In order to keep full path on soft deletion, create parent directories before move
 						parentdir="$(dirname "$files")"
 						if [ "$parentdir" != "." ]; then

--- a/osync.sh
+++ b/osync.sh
@@ -2079,7 +2079,7 @@ local TARGET_STATE_DIR="${TARGET[1]}${TARGET[3]}"
 local DELETE_CMD=(
 $SSH_CMD ERROR_ALERT=0 sync_on_changes=$sync_on_changes _SILENT=$_SILENT _DEBUG=$_DEBUG _DRYRUN=$_DRYRUN _VERBOSE=$_VERBOSE COMMAND_SUDO=$COMMAND_SUDO FILE_LIST="$(EscapeSpaces "$TARGET_STATE_DIR/$deleted_list_file")" REPLICA_DIR="$(EscapeSpaces "$replica_dir")" DELETE_DIR="$(EscapeSpaces "$deletion_dir")" FAILED_DELETE_LIST="$(EscapeSpaces "${TARGET[1]}${TARGET[3]}/$deleted_failed_list_file")" 'bash -s'
 )
-local DELETE_CMD_INPUT = $(cat << 'ENDSSH'
+local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 	## The following lines are executed remotely
 	function _logger {
 		local value="${1}" # What to log

--- a/osync.sh
+++ b/osync.sh
@@ -2173,7 +2173,7 @@ local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 						$COMMAND_SUDO rm -rf "$REPLICA_DIR$files"
 						if [ $? != 0 ]; then
 							Logger "Cannot delete $REPLICA_DIR$files" "ERROR"
-							echo "$files" >> "$TARGET_STATE_DIR/$FAILED_DELETE_LIST"
+							echo "$files" >> "$FAILED_DELETE_LIST"
 						fi
 					fi
 				fi

--- a/osync.sh
+++ b/osync.sh
@@ -2128,6 +2128,7 @@ local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 	IFS=$'\r\n'
 	for files in $(cat "$FILE_LIST")
 	do
+		Logger "Processing file $files" "DEBUG"
 		if [[ "$files" != "$previous_file/"* ]] && [ "$files" != "" ]; then
 			if [ ! -d "$REPLICA_DIR$DELETE_DIR" ]; then
 					$COMMAND_SUDO mkdir -p "$REPLICA_DIR$DELETE_DIR"
@@ -2166,6 +2167,7 @@ local DELETE_CMD_INPUT=$(cat << 'ENDSSH'
 					Logger "Deleting $REPLICA_DIR$files" "NOTICE"
 				fi
 
+				Logger "Full path for deletion: ""$REPLICA_DIR$files" "DEBUG"
 				if [ $_DRYRUN -ne 1 ]; then
 					if [ -e "$REPLICA_DIR$files" ]; then
 						$COMMAND_SUDO rm -rf "$REPLICA_DIR$files"


### PR DESCRIPTION
This fixes several problems in the current file deletion code:
- absent TARGET_STATE_DIR variable
- typo in soft deletion code
- unneeded "$TARGET_STATE_DIR/" in hard file deletion code
- Logger at remote side logs to $LOG_FILE altough it points to a file at initiator filesystem. This fix now just prints to STDERR

Also I added printing the deletion command arguments and input (remote script) to DEBUG logs because I was in stupor when I tried to figure out what's wrong for the first time.
