### PR TITLE
Make timestamp checking more flexible for cross-filesystem sync

### DIFF
--- a/dev/debug_osync.sh
+++ b/dev/debug_osync.sh
@@ -1803,7 +1803,7 @@ function InitRemoteOSDependingSettings {
 	fi
 
 	## Set rsync default arguments
-	RSYNC_ARGS="-rltD -8"
+	RSYNC_ARGS="-rltD -8 --modify-window=2"
 	if [ "$_DRYRUN" == true ]; then
 		RSYNC_DRY_ARG="-n"
 		DRY_WARNING="/!\ DRY RUN "

--- a/dev/debug_osync_target_helper.sh
+++ b/dev/debug_osync_target_helper.sh
@@ -1768,7 +1768,7 @@ function InitRemoteOSDependingSettings {
 	fi
 
 	## Set rsync default arguments
-	RSYNC_ARGS="-rltD -8"
+	RSYNC_ARGS="-rltD -8 --modify-window=2"
 	if [ "$_DRYRUN" == true ]; then
 		RSYNC_DRY_ARG="-n"
 		DRY_WARNING="/!\ DRY RUN "

--- a/dev/ofunctions.sh
+++ b/dev/ofunctions.sh
@@ -1783,7 +1783,7 @@ function InitRemoteOSDependingSettings {
 	fi
 
 	## Set rsync default arguments
-	RSYNC_ARGS="-rltD -8"
+	RSYNC_ARGS="-rltD -8 --modify-window=2"
 	if [ "$_DRYRUN" == true ]; then
 		RSYNC_DRY_ARG="-n"
 		DRY_WARNING="/!\ DRY RUN "

--- a/osync.sh
+++ b/osync.sh
@@ -1645,7 +1645,7 @@ function InitRemoteOSDependingSettings {
 	fi
 
 	## Set rsync default arguments
-	RSYNC_ARGS="-rltD -8"
+	RSYNC_ARGS="-rltD -8 --modify-window=2"
 	if [ "$_DRYRUN" == true ]; then
 		RSYNC_DRY_ARG="-n"
 		DRY_WARNING="/!\ DRY RUN "

--- a/osync_target_helper.sh
+++ b/osync_target_helper.sh
@@ -1639,7 +1639,7 @@ function InitRemoteOSDependingSettings {
 	fi
 
 	## Set rsync default arguments
-	RSYNC_ARGS="-rltD -8"
+	RSYNC_ARGS="-rltD -8 --modify-window=2"
 	if [ "$_DRYRUN" == true ]; then
 		RSYNC_DRY_ARG="-n"
 		DRY_WARNING="/!\ DRY RUN "


### PR DESCRIPTION
The timestamps of different filesystems are sometimes not entirely in sync. The result of this is, that all of the data gets copied with every sync. I experienced this myself when trying to sync files from an ext4 to a FAT32 filesystem. This can be prevented with the `--modify-window` argument for `rsync` as suggested [here](https://askubuntu.com/a/187028). This should not have any side effects as far as I can tell as long as you don't sync something twice within 2 seconds.