### PR TITLE
Fixed variables that required config file

### DIFF
--- a/dev/debug_osync.sh
+++ b/dev/debug_osync.sh
@@ -5295,6 +5295,14 @@ if [ $_QUICK_SYNC -eq 2 ]; then
 		HARD_MAX_EXEC_TIME=0
 	fi
 
+	if [ $(IsInteger $MAX_EXEC_TIME_PER_CMD_BEFORE) -ne 1 ]; then
+		MAX_EXEC_TIME_PER_CMD_BEFORE=0
+	fi
+
+	if [ $(IsInteger $MAX_EXEC_TIME_PER_CMD_AFTER) -ne 1 ]; then
+		MAX_EXEC_TIME_PER_CMD_AFTER=0
+	fi
+
 	if [ "$PATH_SEPARATOR_CHAR" == "" ]; then
 		PATH_SEPARATOR_CHAR=";"
 	fi

--- a/dev/debug_osync.sh
+++ b/dev/debug_osync.sh
@@ -5298,7 +5298,11 @@ if [ $_QUICK_SYNC -eq 2 ]; then
 	if [ "$PATH_SEPARATOR_CHAR" == "" ]; then
 		PATH_SEPARATOR_CHAR=";"
 	fi
+
+	if [ $(IsInteger $MIN_WAIT) -ne 1 ]; then
 		MIN_WAIT=30
+
+	fi
 else
 	ConfigFile="${1}"
 	LoadConfigFile "$ConfigFile"

--- a/dev/n_osync.sh
+++ b/dev/n_osync.sh
@@ -2704,7 +2704,10 @@ if [ $_QUICK_SYNC -eq 2 ]; then
 	if [ "$PATH_SEPARATOR_CHAR" == "" ]; then
 		PATH_SEPARATOR_CHAR=";"
 	fi
+
+	if [ $(IsInteger $MIN_WAIT) -ne 1 ]; then
 		MIN_WAIT=30
+	fi
 else
 	ConfigFile="${1}"
 	LoadConfigFile "$ConfigFile"

--- a/dev/n_osync.sh
+++ b/dev/n_osync.sh
@@ -2701,6 +2701,14 @@ if [ $_QUICK_SYNC -eq 2 ]; then
 		HARD_MAX_EXEC_TIME=0
 	fi
 
+	if [ $(IsInteger $MAX_EXEC_TIME_PER_CMD_BEFORE) -ne 1 ]; then
+		MAX_EXEC_TIME_PER_CMD_BEFORE=0
+	fi
+
+	if [ $(IsInteger $MAX_EXEC_TIME_PER_CMD_AFTER) -ne 1 ]; then
+		MAX_EXEC_TIME_PER_CMD_AFTER=0
+	fi
+
 	if [ "$PATH_SEPARATOR_CHAR" == "" ]; then
 		PATH_SEPARATOR_CHAR=";"
 	fi


### PR DESCRIPTION
I was unable to set `MIN_WAIT` without using a config file. With this fix, this type of configuration works: `MIN_WAIT=3 osync.sh`.