### PR TITLE
osync-srv: Fix syntax errors when setting errno

### DIFF
--- a/osync-srv
+++ b/osync-srv
@@ -60,7 +60,7 @@ start() {
 			echo "$prog successfully started for configuration file $cfgfile"
 		else
 			echo "Cannot start $prog for configuration file $cfgfile"
-			$errno = 1
+			errno=1
 		fi
 	done
 
@@ -106,7 +106,7 @@ status() {
 			echo "$prog instance $(basename $pfile) is running (pid $(cat $pfile))"
 		else
 			echo "$prog instance $pfile (pid $(cat $pfile)) is dead but pidfile exists."
-			$errno=1
+			errno=1
 		fi
 	done
 


### PR DESCRIPTION
Two instances in the osync-srv script throw an error when setting errno to 1.
In both instances errno is expanded from '$errno=1' to '0=1'.
In the first instance there is invalid spacing around the equals symbol.

Signed-off-by: Jookia <166291@gmail.com>