### PR TITLE
Fix install on MacOS to not return error code 2 after a normal install

### DIFF
--- a/dev/common_install.sh
+++ b/dev/common_install.sh
@@ -42,6 +42,7 @@ include #### GetConfFileValue SUBSET ####
 
 function SetLocalOSSettings {
 	USER=root
+	DO_INIT=true
 
 	# LOCAL_OS and LOCAL_OS_FULL are global variables set at GetLocalOS
 
@@ -51,6 +52,7 @@ function SetLocalOSSettings {
 		;;
 		*"MacOSX"*)
 		GROUP=admin
+		DO_INIT=false
 		;;
 		*"msys"*|*"Cygwin"*)
 		USER=""
@@ -425,7 +427,11 @@ umask 0022
 
 GetLocalOS
 SetLocalOSSettings
-GetInit
+# On Mac OS this always produces a warning which causes the installer to fail with exit code 2
+# Since we know it won't work anyway, and that's fine, just skip this step
+if $DO_INIT; then
+	GetInit
+fi
 
 STATS_LINK="http://instcount.netpower.fr?program=$PROGRAM&version=$PROGRAM_VERSION&os=$OS&action=$ACTION"
 


### PR DESCRIPTION
~_I'm not sure where the `env LOCAL_OS="$REMOTE_OS" \` bits came from or if they are correct.  Happened when I did the `./merge.sh osync`._~ I just went through the old PRs and noticed that I probably shouldn't have included the result of the merge.  Reverted those diffs and re-pushed.

The problem I'm trying to fix here is that on Mac OS the installer doesn't find an init system (expected) so it spits out a warning.  This, in turn, causes the installer to use return code 2.  The non-zero exit code prevents using this with homebrew to manage the installation.

By simply bypassing the init check (since we know it would fail anyway), it prevents the problem and allows the installer to return with a zero exit code.