### PR TITLE
Fix FileMove (used on deletions) not working for directories on macOS

### DIFF
--- a/dev/debug_osync.sh
+++ b/dev/debug_osync.sh
@@ -2477,8 +2477,16 @@ function FileMove () {
 		mv -f "$source" "$dest"
 		return $?
 	elif [ -w "$source" ]; then
-		[ -f "$dest" ] && rm -f "$dest"
-		cp -p "$source" "$dest" && rm -f "$source"
+		if [ -f "$dest" ]; then # for files we don't need recursive delete
+			rm -f "$dest"
+		elif [ -d "$dest" ]; then # for directories we need recursive delete
+			rm -rf "$dest"
+		fi
+		if [ -f "$source" ]; then
+			cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete
+		elif [ -d "$source" ]; then
+			cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete
+		fi
 		return $?
 	else
 		return -1
@@ -4865,8 +4873,16 @@ function FileMove () {
 		mv -f "$source" "$dest"
 		return $?
 	elif [ -w "$source" ]; then
-		[ -f "$dest" ] && rm -f "$dest"
-		cp -p "$source" "$dest" && rm -f "$source"
+		if [ -f "$dest" ]; then # for files we don't need recursive delete
+			rm -f "$dest"
+		elif [ -d "$dest" ]; then # for directories we need recursive delete
+			rm -rf "$dest"
+		fi
+		if [ -f "$source" ]; then
+			cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete
+		elif [ -d "$source" ]; then
+			cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete
+		fi
 		return $?
 	else
 		return -1

--- a/dev/ofunctions.sh
+++ b/dev/ofunctions.sh
@@ -2504,8 +2504,16 @@ function FileMove () {
 		mv -f "$source" "$dest"
 		return $?
 	elif [ -w "$source" ]; then
-		[ -f "$dest" ] && rm -f "$dest"
-		cp -p "$source" "$dest" && rm -f "$source"
+		if [ -f "$dest" ]; then # for files we don't need recursive delete
+			rm -f "$dest"
+		elif [ -d "$dest" ]; then # for directories we need recursive delete
+			rm -rf "$dest"
+		fi
+		if [ -f "$source" ]; then
+			cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete
+		elif [ -d "$source" ]; then
+			cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete
+		fi
 		return $?
 	else
 		return -1

--- a/osync.sh
+++ b/osync.sh
@@ -2327,8 +2327,16 @@ function FileMove () {
 		mv -f "$source" "$dest"
 		return $?
 	elif [ -w "$source" ]; then
-		[ -f "$dest" ] && rm -f "$dest"
-		cp -p "$source" "$dest" && rm -f "$source"
+		if [ -f "$dest" ]; then # for files we don't need recursive delete
+			rm -f "$dest"
+		elif [ -d "$dest" ]; then # for directories we need recursive delete
+			rm -rf "$dest"
+		fi
+		if [ -f "$source" ]; then
+			cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete
+		elif [ -d "$source" ]; then
+			cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete
+		fi
 		return $?
 	else
 		return -1
@@ -4657,8 +4665,16 @@ function FileMove () {
 		mv -f "$source" "$dest"
 		return $?
 	elif [ -w "$source" ]; then
-		[ -f "$dest" ] && rm -f "$dest"
-		cp -p "$source" "$dest" && rm -f "$source"
+		if [ -f "$dest" ]; then # for files we don't need recursive delete
+			rm -f "$dest"
+		elif [ -d "$dest" ]; then # for directories we need recursive delete
+			rm -rf "$dest"
+		fi
+		if [ -f "$source" ]; then
+			cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete
+		elif [ -d "$source" ]; then
+			cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete
+		fi
 		return $?
 	else
 		return -1


### PR DESCRIPTION
On macOS and when using soft deletion, deleting directories and attempting a (local) sync osync tries to copy and delete the source directory in `FileMove`. 

This previously was done with `cp -p "$source" "$dest" && rm -f "$source" # for files we don't need recursive copy & delete`.
but for directories we need the `-r` flags for recursive ops: `cp -rp "$source" "$dest" && rm -rf "$source" # for directories we need recursive copy & delete`.

I implemented this to keep the copy & delete without flag in case that the source is only a file `[ -f ]`, although we could just simply use `-r` for both.

Moreover, the deletion of the target file/directory to store the soft-deleted file/directory was done in the same way.

Done for this PR:
- [x] When submitting a pull request, please modify the files in dev directory rather than those generated on-the-fly. 
- [x] You may find all code contained in osync.sh in n_osync.sh and ofunctions.sh
- [x] You may run your modified code by using `merge.sh osync` in order to generate ../osync.sh
- [x] Consider reading CODING_CONVENTIONS.TXT before submitting a patch.
- [ ] Test suite passed
