### PR TITLE
Update uninstaller to remove all services files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -907,13 +907,22 @@ function RemoveAll {
 	else
 		Logger "Skipping removal of [$BIN_DIR/$SSH_FILTER] because other programs present that need it." "NOTICE"
 	fi
-	RemoveFile "$SERVICE_DIR_SYSTEMD_SYSTEM/$SERVICE_FILE_SYSTEMD_SYSTEM"
-	RemoveFile "$SERVICE_DIR_SYSTEMD_USER/$SERVICE_FILE_SYSTEMD_USER"
-	RemoveFile "$SERVICE_DIR_INIT/$SERVICE_FILE_INIT"
 
-	RemoveFile "$TARGET_HELPER_SERVICE_DIR_SYSTEMD_SYSTEM/$SERVICE_FILE_SYSTEMD_SYSTEM"
-	RemoveFile "$TARGET_HELPER_SERVICE_DIR_SYSTEMD_USER/$SERVICE_FILE_SYSTEMD_USER"
-	RemoveFile "$TARGET_HELPER_SERVICE_DIR_INIT/$SERVICE_FILE_INIT"
+	# Try to uninstall every possible service file
+	#if [ $init == "systemd" ]; then
+		RemoveFile "$SERVICE_DIR_SYSTEMD_SYSTEM/$SERVICE_FILE_SYSTEMD_SYSTEM"
+		RemoveFile "$SERVICE_DIR_SYSTEMD_USER/$SERVICE_FILE_SYSTEMD_USER"
+		RemoveFile "$SERVICE_DIR_SYSTEMD_SYSTEM/$TARGET_HELPER_SERVICE_FILE_SYSTEMD_SYSTEM"
+		RemoveFile "$SERVICE_DIR_SYSTEMD_USER/$TARGET_HELPER_SERVICE_FILE_SYSTEMD_USER"
+	#elif [ $init == "initV" ]; then
+		RemoveFile "$SERVICE_DIR_INIT/$SERVICE_FILE_INIT"
+		RemoveFile "$SERVICE_DIR_INIT/$TARGET_HELPER_SERVICE_FILE_INIT"
+	#elif [ $init == "openrc" ]; then
+		RemoveFile "$SERVICE_DIR_OPENRC/$SERVICE_FILE_OPENRC"
+		RemoveFile "$SERVICE_DIR_OPENRC/$TARGET_HELPER_SERVICE_FILE_OPENRC"
+	#else
+		#Logger "Can't uninstall from initV, systemd or openRC." "WARN"
+	#fi
 
 	Logger "Skipping configuration files in [$CONF_DIR]. You may remove this directory manually." "NOTICE"
 }


### PR DESCRIPTION
Untested, please test. You can get rid of the commented code, uncomment them or just leave it as it is.

I came across this issue, because after `--remove` (I tried multiple init systems) the following files were still present:
```
/etc/init.d/osync-target-helper-srv
/etc/systemd/user/osync-target-helper-srv\@.service.user
```