### PR TITLE
Kerberos patch

### DIFF
--- a/dev/n_osync.sh
+++ b/dev/n_osync.sh
@@ -234,8 +234,8 @@ function CheckCurrentConfigAll {
 		exit 1
 	fi
 
-	if [ "$REMOTE_OPERATION" == true ] && ([ ! -f "$SSH_RSA_PRIVATE_KEY" ] && [ ! -f "$SSH_PASSWORD_FILE" ]); then
-		Logger "Cannot find rsa private key [$SSH_RSA_PRIVATE_KEY] nor password file [$SSH_PASSWORD_FILE]. No authentication method provided." "CRITICAL"
+	if [ "$REMOTE_OPERATION" == true ] && ([ ! -f "$SSH_RSA_PRIVATE_KEY" ] && [ ! -f "$SSH_PASSWORD_FILE" ] && [ ! $KRB5 ]); then
+		Logger "Cannot find rsa private key [$SSH_RSA_PRIVATE_KEY] nor password file [$SSH_PASSWORD_FILE] nor KRB5CCFILE. No authentication method provided." "CRITICAL"
 		exit 1
 	fi
 
@@ -2918,6 +2918,7 @@ function Usage {
 	echo "--initiator=\"\"		 Master replica path. Will contain state and backup directory (is mandatory)"
 	echo "--target=\"\" 		 Local or remote target replica path. Can be a ssh uri like ssh://user@host.com:22//path/to/target/replica (is mandatory)"
 	echo "--rsakey=\"\"		 Alternative path to rsa private key for ssh connection to target replica"
+	echo "--krb5			              use KRB5 credential cache"
 	echo "--ssh-controlmaster      Allow using a single TCP connection for all ssh calls. Will make remote sync faster, but may fail easier on lossy links"
 	echo "--password-file=\"\"       If no rsa private key is used for ssh authentication, a password file can be used"
 	echo "--remote-token=\"\"        When using ssh filter protection, you must specify the remote token set in ssh_filter.sh"
@@ -3094,7 +3095,11 @@ function GetCommandlineArguments {
 			_DRYRUN=true
 			opts=$opts" --dry"
 			;;
-			--silent)
+			--krb5)
+			KRB5=true
+			opts=$opts" --krb5"
+			;;
+	    --silent)
 			_LOGGER_SILENT=true
 			opts=$opts" --silent"
 			;;

--- a/dev/ofunctions.sh
+++ b/dev/ofunctions.sh
@@ -691,7 +691,7 @@ function SendEmail {
 			encryption_string=
 		elif [ "$encryption" == "tls" ]; then
 			encryption_string=-starttls
-		elif [ "$encryption" == "ssl" ]:; then
+		elif [ "$encryption" == "ssl" ]; then
 			encryption_string=-ssl
 		fi
 		if [ "$smtpUser" != "" ] && [ "$smtpPassword" != "" ]; then
@@ -2139,6 +2139,11 @@ function PostInit {
 		SSH_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p ssh) $SSH_COMP -q $SSH_OPTS $REMOTE_USER@$REMOTE_HOST -p $REMOTE_PORT"
 		SCP_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p scp) $SSH_COMP -q -P $REMOTE_PORT"
 		RSYNC_SSH_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p ssh) $SSH_COMP -q $SSH_OPTS -p $REMOTE_PORT"
+  elif [ $KRB5 ]; then
+    SSH_PASSWORD=""
+    SSH_CMD="$(type -p ssh) $SSH_COMP -q $SSH_OPTS $REMOTE_USER@$REMOTE_HOST -p $REMOTE_PORT"
+    SCP_CMD="$(type -p scp) $SSH_COMP -q -P $REMOTE_PORT"
+    RSYNC_SSH_CMD="$(type -p ssh) $SSH_COMP -q $SSH_OPTS -p $REMOTE_PORT"
 	else
 		SSH_PASSWORD=""
 		SSH_CMD=""

--- a/osync.sh
+++ b/osync.sh
@@ -636,7 +636,7 @@ function SendEmail {
 			encryption_string=
 		elif [ "$encryption" == "tls" ]; then
 			encryption_string=-starttls
-		elif [ "$encryption" == "ssl" ]:; then
+		elif [ "$encryption" == "ssl" ]; then
 			encryption_string=-ssl
 		fi
 		if [ "$smtpUser" != "" ] && [ "$smtpPassword" != "" ]; then
@@ -1970,6 +1970,11 @@ function PostInit {
 		SSH_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p ssh) $SSH_COMP -q $SSH_OPTS $REMOTE_USER@$REMOTE_HOST -p $REMOTE_PORT"
 		SCP_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p scp) $SSH_COMP -q -P $REMOTE_PORT"
 		RSYNC_SSH_CMD="$(type -p sshpass) -f $SSH_PASSWORD_FILE $(type -p ssh) $SSH_COMP -q $SSH_OPTS -p $REMOTE_PORT"
+  elif [ $KRB5 ]; then
+    SSH_PASSWORD=""
+    SSH_CMD="$(type -p ssh) $SSH_COMP -q $SSH_OPTS $REMOTE_USER@$REMOTE_HOST -p $REMOTE_PORT"
+    SCP_CMD="$(type -p scp) $SSH_COMP -q -P $REMOTE_PORT"
+    RSYNC_SSH_CMD="$(type -p ssh) $SSH_COMP -q $SSH_OPTS -p $REMOTE_PORT"
 	else
 		SSH_PASSWORD=""
 		SSH_CMD=""
@@ -2683,8 +2688,8 @@ function CheckCurrentConfigAll {
 		exit 1
 	fi
 
-	if [ "$REMOTE_OPERATION" == true ] && ([ ! -f "$SSH_RSA_PRIVATE_KEY" ] && [ ! -f "$SSH_PASSWORD_FILE" ]); then
-		Logger "Cannot find rsa private key [$SSH_RSA_PRIVATE_KEY] nor password file [$SSH_PASSWORD_FILE]. No authentication method provided." "CRITICAL"
+	if [ "$REMOTE_OPERATION" == true ] && ([ ! -f "$SSH_RSA_PRIVATE_KEY" ] && [ ! -f "$SSH_PASSWORD_FILE" ] && [ ! $KRB5 ]); then
+		Logger "Cannot find rsa private key [$SSH_RSA_PRIVATE_KEY] nor password file [$SSH_PASSWORD_FILE] nor KRB5CCFILE. No authentication method provided." "CRITICAL"
 		exit 1
 	fi
 
@@ -6375,6 +6380,7 @@ function Usage {
 	echo "--initiator=\"\"		 Master replica path. Will contain state and backup directory (is mandatory)"
 	echo "--target=\"\" 		 Local or remote target replica path. Can be a ssh uri like ssh://user@host.com:22//path/to/target/replica (is mandatory)"
 	echo "--rsakey=\"\"		 Alternative path to rsa private key for ssh connection to target replica"
+	echo "--krb5			              use KRB5 credential cache"
 	echo "--ssh-controlmaster      Allow using a single TCP connection for all ssh calls. Will make remote sync faster, but may fail easier on lossy links"
 	echo "--password-file=\"\"       If no rsa private key is used for ssh authentication, a password file can be used"
 	echo "--remote-token=\"\"        When using ssh filter protection, you must specify the remote token set in ssh_filter.sh"
@@ -6550,7 +6556,11 @@ function GetCommandlineArguments {
 			_DRYRUN=true
 			opts=$opts" --dry"
 			;;
-			--silent)
+			--krb5)
+			KRB5=true
+			opts=$opts" --krb5"
+			;;
+	    --silent)
 			_LOGGER_SILENT=true
 			opts=$opts" --silent"
 			;;

--- a/sync.conf.example
+++ b/sync.conf.example
@@ -21,6 +21,9 @@ SSH_RSA_PRIVATE_KEY="/home/backupuser/.ssh/id_rsa"
 ## Alternatively, you may specify an SSH password file (less secure). Needs sshpass utility installed.
 SSH_PASSWORD_FILE=""
 
+## use the KRB5 credential cache to access SSH or rsync
+#KRB5=true
+
 ## When using ssh filter, you must specify a remote token matching the one setup in authorized_keys
 _REMOTE_TOKEN=SomeAlphaNumericToken9
 


### PR DESCRIPTION
with KRB5 switch one can use the kerberos credential cache to access SSH or RSYNC
This is useful when using osync as a user profile replication service. When bootstrapping a profile on a new client there is no ssh-key for the user but mostly a kerberos credential
