### PR TITLE
Fix typos in install script

### DIFF
--- a/dev/common_install.sh
+++ b/dev/common_install.sh
@@ -259,7 +259,7 @@ function CopyServiceFiles {
 
 
 		Logger "Created [$SERVICE_NAME] service in [$SERVICE_DIR_SYSTEMD_SYSTEM] and [$SERVICE_DIR_SYSTEMD_USER]." "NOTICE"
-		Logger "Can be activated with [systemctl start SERVICE_NAME@instance.conf] where instance.conf is the name of the config file in $CONF_DIR." "NOTICE"
+		Logger "Can be activated with [systemctl start $SERVICE_NAME@instance.conf] where instance.conf is the name of the config file in $CONF_DIR." "NOTICE"
 		Logger "Can be enabled on boot with [systemctl enable $SERVICE_NAME@instance.conf]." "NOTICE"
 		Logger "In userland, active with [systemctl --user start $SERVICE_NAME@instance.conf]." "NOTICE"
 	elif ([ "$init" == "initV" ] && [ -f "$SCRIPT_PATH/$SERVICE_FILE_INIT" ] && [ -d "$SERVICE_DIR_INIT" ]); then
@@ -354,8 +354,8 @@ function RemoveAll {
 function Usage {
 	echo "Installs $PROGRAM into $BIN_DIR"
 	echo "options:"
-	echo "--silent		Will log and bypass user interaction."
-	echo "--no-stats	Used with --silent in order to refuse sending anonymous install stats."
+	echo "--silent          Will log and bypass user interaction."
+	echo "--no-stats        Used with --silent in order to refuse sending anonymous install stats."
 	echo "--remove          Remove the program."
 	echo "--prefix=/path    Use prefix to install path."
 	exit 127


### PR DESCRIPTION
Re-apply changes that have been overwritten because I edited `install.sh` instead of `dev/common_install.sh` in my previous PRs.